### PR TITLE
Bump action versions to fix deprecation warnings

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'adopt'
@@ -30,12 +30,12 @@ jobs:
       with:
         arguments: build --info --no-daemon
     - name: Archive build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Build Result
         path: glsl-transformer/build/libs/
     - name: Archive test report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test Report
         path: glsl-transformer/build/reports/tests/test/


### PR DESCRIPTION
Bumps `actions/checkout`, `actions/setup-java` and `actions/upload-artifact` versions to `v3`.

There are no breaking changes in them, they just decided to bump major just because they updated the node dependency or something iirc.

This fixes the deprecation warnings in action runs.