### PR TITLE
Fixing tests: getResourcePath on windows was giving windows-style path

### DIFF
--- a/glsl-transformer/src/test/java/io/github/douira/glsl_transformer/test_util/TestResourceManagerBase.java
+++ b/glsl-transformer/src/test/java/io/github/douira/glsl_transformer/test_util/TestResourceManagerBase.java
@@ -75,7 +75,7 @@ public class TestResourceManagerBase {
   }
 
   private static Path getResourcePath(Path resource) {
-    return getResourcePath(resource.toString());
+    return getResourcePath(resource.toString().replace('\\', '/'));
   }
 
   private static Path getResourcePath(String resource) {


### PR DESCRIPTION
When running tests on windows TestResourceManagerBase.getResourcePath was outputing windows-style paths on windows preventing proper resolution of test shader files.